### PR TITLE
Safer charOffset for any body types

### DIFF
--- a/Projects/Zone+/src/Zone.lua
+++ b/Projects/Zone+/src/Zone.lua
@@ -236,7 +236,7 @@ function Zone:getPlayer(player)
 	local hrp = char and char:FindFirstChild("HumanoidRootPart")
 	if hrp then
 		local charOffset = hrp.Size.Y * -1.4
-		local hum = char:FindFirstChild("Humanoid");
+		local hum = char and char:FindFirstChild("Humanoid");
 		if hum and hum:IsA("Humanoid") then
 			charOffset = -hrp.Size.Y/2 - hum.HipHeight + 0.5
 		end

--- a/Projects/Zone+/src/Zone.lua
+++ b/Projects/Zone+/src/Zone.lua
@@ -236,6 +236,10 @@ function Zone:getPlayer(player)
 	local hrp = char and char:FindFirstChild("HumanoidRootPart")
 	if hrp then
 		local charOffset = hrp.Size.Y * -1.4
+		local hum = char:FindFirstChild("Humanoid");
+		if hum and hum:IsA("Humanoid") then
+			charOffset = -hrp.Size.Y/2 - hum.HipHeight + 0.5
+		end
 		local origin = hrp.Position + Vector3.new(0, charOffset, 0)
 		local hitValidPart = self:castRay(origin, self.groupParts)
 		return hitValidPart


### PR DESCRIPTION
getPlayer wasn't working a custom character due to an enlarged HumanoidRootPart, this fixed that.