### PR TITLE
Add support for icons on the Right Hand Side

### DIFF
--- a/Projects/Topbar+/src/Icon.lua
+++ b/Projects/Topbar+/src/Icon.lua
@@ -76,6 +76,7 @@ function Icon.new(name, imageId, order)
 	self:setImageSize(20)
 	self.order = order or 1
 	self.enabled = true
+	self.rightSide = false
 	self.totalNotifications = 0
 	self.toggleFunction = function() end
 	self.hoverFunction = function() end
@@ -137,6 +138,16 @@ end
 
 function Icon:setOrder(order)
 	self.order = tonumber(order) or 1
+	self.updated:Fire()
+end
+
+function Icon:setLeft()
+	self.rightSide = false
+	self.updated:Fire()
+end
+
+function Icon:setRight()
+	self.rightSide = true
 	self.updated:Fire()
 end
 

--- a/Projects/Topbar+/src/IconController.lua
+++ b/Projects/Topbar+/src/IconController.lua
@@ -53,10 +53,8 @@ function IconController:createIcon(name, imageId, order)
 	-- Events
 	local function updateIcon()
 		local iconDetails = topbarIcons[name]
-		if not iconDetails then
-			warn(("%sFailed to update Icon '%s': icon not found."):format(ERROR_START, name))
-			return false
-		end
+		assert(iconDetails, ("Failed to update Icon '%s': icon not found."):format(name))
+
 		iconDetails.order = icon.order or 1
 		local orderedIconDetails = {}
 		for name, details in pairs(topbarIcons) do

--- a/Projects/Topbar+/src/IconController.lua
+++ b/Projects/Topbar+/src/IconController.lua
@@ -57,23 +57,39 @@ function IconController:createIcon(name, imageId, order)
 
 		iconDetails.order = icon.order or 1
 		local orderedIconDetails = {}
+		local rightOrderedIconDetails = {}
 		for name, details in pairs(topbarIcons) do
 			if details.icon.enabled == true then
-				table.insert(orderedIconDetails, details)
+				if details.icon.rightSide then
+					table.insert(rightOrderedIconDetails, details)
+				else
+					table.insert(orderedIconDetails, details)
+				end
 			end
-		end
+		end		
 		if #orderedIconDetails > 1 then
 			table.sort(orderedIconDetails, function(a,b) return a.order < b.order end)
 		end
-		local startPosition = 104
+		if #rightOrderedIconDetails > 1 then
+			table.sort(rightOrderedIconDetails, function(a,b) return a.order < b.order end)
+		end
+		local leftStartPosition, rightStartPosition = 104, -90
 		local positionIncrement = 44
 		if not starterGui:GetCoreGuiEnabled("Chat") then
-			startPosition = startPosition - positionIncrement
+			leftStartPosition = leftStartPosition - positionIncrement
+		end
+		if not starterGui:GetCoreGuiEnabled(Enum.CoreGuiType.PlayerList) and not starterGui:GetCoreGuiEnabled(Enum.CoreGuiType.Backpack) and not starterGui:GetCoreGuiEnabled(Enum.CoreGuiType.EmotesMenu) then
+			rightStartPosition = rightStartPosition + positionIncrement
 		end
 		for i, details in pairs(orderedIconDetails) do
 			local container = details.icon.objects.container
-			local iconX = startPosition + (i-1)*positionIncrement
+			local iconX = leftStartPosition + (i-1)*positionIncrement
 			container.Position = UDim2.new(0, iconX, 0, 4)
+		end
+		for i, details in pairs(rightOrderedIconDetails) do
+			local container = details.icon.objects.container
+			local iconX = rightStartPosition - (i-1)*positionIncrement
+			container.Position = UDim2.new(1, iconX, 0, 4)
 		end
 		return true
 	end


### PR DESCRIPTION
This PR adds the ability to create icons on the right hand side of the Topbar using the Topbar+ module
Once an icon is created, you can use the methods `:setRight()` and `:setLeft()` to snap the icon to the left or right side of the Topbar
Closes #12 