### PR TITLE
Topbar+ Long text "icons" support

### DIFF
--- a/Projects/Topbar+/src/IconController.lua
+++ b/Projects/Topbar+/src/IconController.lua
@@ -77,13 +77,13 @@ local function updateIconCellSize(icon, controllerEnabled)
 	icon:setCellSize(cellSize*scaleMultiplier)
 end
 
-function IconController:createIcon(name, imageId, order)
+function IconController:createIcon(name, imageId, order, withText)
 	
 	-- Verify data
 	assert(not topbarIcons[name], ("icon '%s' already exists!"):format(name))
 	
 	-- Create and record icon
-	local icon = Icon.new(name, imageId, order)
+	local icon = Icon.new(name, imageId, order, withText)
 	local iconDetails = {name = name, icon = icon, order = icon.order}
 	topbarIcons[name] = iconDetails
 	icon:setOrder(icon.order)
@@ -124,14 +124,14 @@ function IconController:createIcon(name, imageId, order)
 					end
 					return offset
 				end,
-				records = {},
+				records = {}
 			},
 			mid = {
 				startScale = 0.5,
 				getStartOffset = function(totalIconX) 
 					return -totalIconX/2 + (gap/2)
 				end,
-				records = {},
+				records = {}
 			},
 			right = {
 				startScale = 1,
@@ -142,8 +142,8 @@ function IconController:createIcon(name, imageId, order)
 					end
 					return offset
 				end,
-				records = {},
-				--reverseSort = true,
+				records = {}
+				--reverseSort = true
 			},
 		}
 		for _, details in pairs(topbarIcons) do
@@ -197,7 +197,7 @@ function IconController:createIcon(name, imageId, order)
 	return icon
 end
 
-function IconController:setTopbarEnabled(bool,forceBool)
+function IconController:setTopbarEnabled(bool, forceBool)
 	if forceBool == nil then
 		forceBool = true
 	end
@@ -338,7 +338,6 @@ function IconController:enableControllerMode(bool)
 		end
 		toolTip.AnchorPoint = Vector2.new(0.5,0)
 		toolTip.Position = UDim2.new(0.5,0,0,topbar.TopbarContainer.Size.Y.Offset+60)
-		toolTip.Visible = false
 	else
 		if userInputService.GamepadEnabled and controllerOptionIcon then
 			--mouse user but might want to use controller
@@ -359,8 +358,8 @@ function IconController:enableControllerMode(bool)
 		topbar.TopbarContainer.Visible = checkTopbarEnabled()
 		indicator.Visible = false
 		toolTip.AnchorPoint = Vector2.new(0,1)
-		toolTip.Visible = false
 	end
+	toolTip.Visible = false
 end
 
 function updateDevice()
@@ -401,7 +400,7 @@ function IconController:createFakeChat(theme)
 	if not icon then
 		icon = self:createIcon(iconName, "rbxasset://textures/ui/TopBar/chatOff.png", -1)
 		-- Open chat via Slash key
-		icon._fakeChatConnections:give(userInputService.InputEnded:connect(function(inputObject, gameProcessedEvent)
+		icon._fakeChatMaid:give(userInputService.InputEnded:connect(function(inputObject, gameProcessedEvent)
 			if gameProcessedEvent then
 				return "Another menu has priority"
 			elseif not(inputObject.KeyCode == Enum.KeyCode.Slash or inputObject.KeyCode == Enum.SpecialKey.ChatHotkey) then
@@ -415,7 +414,7 @@ function IconController:createFakeChat(theme)
 			icon:select()
 		end))
 		-- ChatActive
-		icon._fakeChatConnections:give(ChatMain.VisibilityStateChanged:connect(function(visibility)
+		icon._fakeChatMaid:give(ChatMain.VisibilityStateChanged:connect(function(visibility)
 			if not icon.ignoreVisibilityStateChange then
 				if visibility == true then
 					icon:select()
@@ -427,14 +426,14 @@ function IconController:createFakeChat(theme)
 		-- Keep when other icons selected
 		icon.deselectWhenOtherIconSelected = false
 		-- Mimic chat notifications
-		icon._fakeChatConnections:give(ChatMain.MessagesChanged:connect(function()
+		icon._fakeChatMaid:give(ChatMain.MessagesChanged:connect(function()
 			if ChatMain:GetVisibility() == true then
 				return "ChatWindow was open"
 			end
 			icon:notify(icon.selected)
 		end))
 		-- Mimic visibility when StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.Chat, state) is called
-		icon._fakeChatConnections:give(ChatMain.CoreGuiEnabled:connect(function(newState)
+		icon._fakeChatMaid:give(ChatMain.CoreGuiEnabled:connect(function(newState)
 			if icon.ignoreVisibilityStateChange then
 				return "ignoreVisibilityStateChange enabled"
 			end
@@ -466,7 +465,7 @@ end
 function IconController:removeFakeChat()
 	local icon = IconController:getIcon(fakeChatName)
 	local enabled = icon.enabled
-	icon._fakeChatConnections:clean()
+	icon._fakeChatMaid:clean()
 	starterGui:SetCoreGuiEnabled("Chat", enabled)
 	IconController:removeIcon(fakeChatName)
 end
@@ -553,11 +552,7 @@ guiService.MenuClosed:Connect(function()
 end)
 guiService.MenuOpened:Connect(function()
 	menuOpen = true
-	if isControllerMode() then
-		IconController:setTopbarEnabled(false,false)
-	else
-		IconController:setTopbarEnabled(IconController.topbarEnabled,false)
-	end
+	IconController:setTopbarEnabled(false,false)
 end)
 
 --Controller

--- a/Projects/Topbar+/src/init.lua
+++ b/Projects/Topbar+/src/init.lua
@@ -44,6 +44,19 @@ iconButton.ImageColor3 = Color3.fromRGB(0, 0, 0)
 iconButton.ScaleType = Enum.ScaleType.Stretch
 iconButton.Parent = iconContainer
 
+local stateOverlay = Instance.new("ImageLabel")
+stateOverlay.BackgroundTransparency = 1
+stateOverlay.Name = "StateOverlay"
+stateOverlay.Position = iconButton.Position
+stateOverlay.Size = iconButton.Size
+stateOverlay.Visible = true
+stateOverlay.ZIndex = iconButton.ZIndex + 1
+stateOverlay.Image = iconButton.Image
+stateOverlay.ImageTransparency = 1
+stateOverlay.ImageColor3 = Color3.fromRGB(255, 255, 255)
+stateOverlay.ScaleType = iconButton.ScaleType
+stateOverlay.Parent = iconButton.Parent
+
 local gradient = Instance.new("UIGradient")
 gradient.Enabled = false
 gradient.Parent = iconButton
@@ -87,6 +100,73 @@ amount.TextColor3 = Color3.fromRGB(31, 33, 35)
 amount.TextScaled = true
 amount.Parent = notification
 
+--CREATE ICON WITH TEXT
+local iconWithTextContainer = Instance.new("Frame")
+iconWithTextContainer.BackgroundTransparency = 1
+iconWithTextContainer.Name = "_IconWithTextTemplate"
+iconWithTextContainer.Position = UDim2.new(0, 104, 0, 4)
+iconWithTextContainer.Size = UDim2.new(0, 32*4, 0, 32)
+iconWithTextContainer.Visible = false
+iconWithTextContainer.ZIndex = 1
+iconWithTextContainer.Parent = topbarContainer
+
+local iconWithTextButton = Instance.new("ImageButton")
+iconWithTextButton.BackgroundTransparency = 1
+iconWithTextButton.Name = "Button"
+iconWithTextButton.Position = UDim2.new(0, 0, 0, 0)
+iconWithTextButton.Size = UDim2.new(1, 0, 1, 0)
+iconWithTextButton.Visible = true
+iconWithTextButton.ZIndex = 2
+iconWithTextButton.Image = "rbxassetid://5027411759"
+iconWithTextButton.ImageTransparency = 0.5
+iconWithTextButton.ImageColor3 = Color3.fromRGB(0, 0, 0)
+iconWithTextButton.ScaleType = Enum.ScaleType.Slice
+iconWithTextButton.SliceCenter = Rect.new(48,48,48,48)
+iconWithTextButton.Parent = iconWithTextContainer
+
+local stateOverlay = Instance.new("ImageLabel")
+stateOverlay.BackgroundTransparency = 1
+stateOverlay.Name = "StateOverlay"
+stateOverlay.Size = UDim2.new(1,0,1,0)
+stateOverlay.Visible = true
+stateOverlay.ZIndex = 3
+stateOverlay.Image = iconWithTextButton.Image
+stateOverlay.ImageTransparency = 1
+stateOverlay.ImageColor3 = Color3.fromRGB(255, 255, 255)
+stateOverlay.ScaleType = iconWithTextButton.ScaleType
+stateOverlay.SliceCenter = iconWithTextButton.SliceCenter
+stateOverlay.Parent = iconWithTextContainer
+
+local gradient = Instance.new("UIGradient")
+gradient.Enabled = false
+gradient.Parent = iconWithTextButton
+
+local iconText = Instance.new("TextLabel")
+iconText.BackgroundTransparency = 1
+iconText.Name = "IconText"
+iconText.ZIndex = 3
+iconText.Size = UDim2.new(1,-32,1,0)
+iconText.Position = UDim2.new(0,32,0,0)
+iconText.Font = Enum.Font.GothamSemibold
+iconText.TextSize = 14
+iconText.TextColor3 = Color3.new(1,1,1)
+iconText.TextXAlignment = Enum.TextXAlignment.Left
+iconText.Parent = iconWithTextButton
+
+local iconFrame = Instance.new("Frame")
+iconFrame.BackgroundTransparency = 1
+iconFrame.Name = "IconFrame"
+iconFrame.Position = UDim2.new(0, 0, 0, 0)
+iconFrame.Size = UDim2.new(0,32,1,0)
+iconFrame.Visible = true
+iconFrame.ZIndex = 2
+iconFrame.Parent = iconWithTextButton
+
+local iconNotification = notification:Clone()
+iconNotification.Parent = iconFrame
+
+local iconWithTextImage = iconImage:Clone()
+iconWithTextImage.Parent = iconFrame
 
 --CREATE DROPDOWN
 local dropdown = Instance.new("Frame")

--- a/Projects/Topbar+/src/init.lua
+++ b/Projects/Topbar+/src/init.lua
@@ -32,17 +32,22 @@ iconContainer.ZIndex = 1
 iconContainer.Parent = topbarContainer
 
 local iconButton = Instance.new("ImageButton")
-iconButton.BackgroundTransparency = 1
+iconButton.ImageTransparency = 0.5
 iconButton.Name = "IconButton"
 iconButton.Position = UDim2.new(0, 0, 0, 0)
 iconButton.Size = UDim2.new(1, 0, 1, 0)
 iconButton.Visible = true
 iconButton.ZIndex = 2
-iconButton.Image = "rbxassetid://5027411759"
-iconButton.ImageTransparency = 0.5
-iconButton.ImageColor3 = Color3.fromRGB(0, 0, 0)
-iconButton.ScaleType = Enum.ScaleType.Stretch
+iconButton.BackgroundTransparency = 1
+iconButton.ImageColor3 = Color3.new(0,0,0)
+iconButton.BorderSizePixel = 0
+iconButton.Image = "http://www.roblox.com/asset/?id=5540166883"
+iconButton.ScaleType = Enum.ScaleType.Crop
 iconButton.Parent = iconContainer
+
+local uiCorner = Instance.new("UICorner")
+uiCorner.CornerRadius = UDim.new(0.3,0)
+uiCorner.Parent = iconButton
 
 local stateOverlay = Instance.new("ImageLabel")
 stateOverlay.BackgroundTransparency = 1
@@ -51,11 +56,16 @@ stateOverlay.Position = iconButton.Position
 stateOverlay.Size = iconButton.Size
 stateOverlay.Visible = true
 stateOverlay.ZIndex = iconButton.ZIndex + 1
-stateOverlay.Image = iconButton.Image
 stateOverlay.ImageTransparency = 1
-stateOverlay.ImageColor3 = Color3.fromRGB(255, 255, 255)
-stateOverlay.ScaleType = iconButton.ScaleType
+stateOverlay.ImageColor3 = Color3.new(1,1,1)
+stateOverlay.BorderSizePixel = 0
+stateOverlay.Image = "http://www.roblox.com/asset/?id=5540166883"
+stateOverlay.ScaleType = Enum.ScaleType.Crop
 stateOverlay.Parent = iconButton.Parent
+
+local stateUiCorner = Instance.new("UICorner")
+stateUiCorner.CornerRadius = uiCorner.CornerRadius
+stateUiCorner.Parent = stateOverlay
 
 local gradient = Instance.new("UIGradient")
 gradient.Enabled = false
@@ -73,6 +83,19 @@ iconImage.ImageTransparency = 0
 iconImage.ImageColor3 = Color3.fromRGB(255, 255, 255)
 iconImage.ScaleType = Enum.ScaleType.Fit
 iconImage.Parent = iconButton
+
+local iconLabel = Instance.new("TextLabel")
+iconLabel.BackgroundTransparency = 1
+iconLabel.Name = "IconLabel"
+iconLabel.AnchorPoint = Vector2.new(0, 0.5)
+iconLabel.Position = UDim2.new(0.5, 0, 0.5, 0)
+iconLabel.Size = UDim2.new(0, 20, 0, 20)
+iconLabel.Text = ""
+iconLabel.TextXAlignment = Enum.TextXAlignment.Left
+iconLabel.Font = Enum.Font.GothamSemibold
+iconLabel.TextSize = 14
+iconLabel.ZIndex = 3
+iconLabel.Parent = iconButton
 
 local notification = Instance.new("ImageLabel")
 notification.BackgroundTransparency = 1
@@ -99,74 +122,6 @@ amount.Text = "0"
 amount.TextColor3 = Color3.fromRGB(31, 33, 35)
 amount.TextScaled = true
 amount.Parent = notification
-
---CREATE ICON WITH TEXT
-local iconWithTextContainer = Instance.new("Frame")
-iconWithTextContainer.BackgroundTransparency = 1
-iconWithTextContainer.Name = "_IconWithTextTemplate"
-iconWithTextContainer.Position = UDim2.new(0, 104, 0, 4)
-iconWithTextContainer.Size = UDim2.new(0, 32*4, 0, 32)
-iconWithTextContainer.Visible = false
-iconWithTextContainer.ZIndex = 1
-iconWithTextContainer.Parent = topbarContainer
-
-local iconWithTextButton = Instance.new("ImageButton")
-iconWithTextButton.BackgroundTransparency = 1
-iconWithTextButton.Name = "Button"
-iconWithTextButton.Position = UDim2.new(0, 0, 0, 0)
-iconWithTextButton.Size = UDim2.new(1, 0, 1, 0)
-iconWithTextButton.Visible = true
-iconWithTextButton.ZIndex = 2
-iconWithTextButton.Image = "rbxassetid://5027411759"
-iconWithTextButton.ImageTransparency = 0.5
-iconWithTextButton.ImageColor3 = Color3.fromRGB(0, 0, 0)
-iconWithTextButton.ScaleType = Enum.ScaleType.Slice
-iconWithTextButton.SliceCenter = Rect.new(48,48,48,48)
-iconWithTextButton.Parent = iconWithTextContainer
-
-local stateOverlay = Instance.new("ImageLabel")
-stateOverlay.BackgroundTransparency = 1
-stateOverlay.Name = "StateOverlay"
-stateOverlay.Size = UDim2.new(1,0,1,0)
-stateOverlay.Visible = true
-stateOverlay.ZIndex = 3
-stateOverlay.Image = iconWithTextButton.Image
-stateOverlay.ImageTransparency = 1
-stateOverlay.ImageColor3 = Color3.fromRGB(255, 255, 255)
-stateOverlay.ScaleType = iconWithTextButton.ScaleType
-stateOverlay.SliceCenter = iconWithTextButton.SliceCenter
-stateOverlay.Parent = iconWithTextContainer
-
-local gradient = Instance.new("UIGradient")
-gradient.Enabled = false
-gradient.Parent = iconWithTextButton
-
-local iconText = Instance.new("TextLabel")
-iconText.BackgroundTransparency = 1
-iconText.Name = "IconText"
-iconText.ZIndex = 3
-iconText.Size = UDim2.new(1,-32,1,0)
-iconText.Position = UDim2.new(0,32,0,0)
-iconText.Font = Enum.Font.GothamSemibold
-iconText.TextSize = 14
-iconText.TextColor3 = Color3.new(1,1,1)
-iconText.TextXAlignment = Enum.TextXAlignment.Left
-iconText.Parent = iconWithTextButton
-
-local iconFrame = Instance.new("Frame")
-iconFrame.BackgroundTransparency = 1
-iconFrame.Name = "IconFrame"
-iconFrame.Position = UDim2.new(0, 0, 0, 0)
-iconFrame.Size = UDim2.new(0,32,1,0)
-iconFrame.Visible = true
-iconFrame.ZIndex = 2
-iconFrame.Parent = iconWithTextButton
-
-local iconNotification = notification:Clone()
-iconNotification.Parent = iconFrame
-
-local iconWithTextImage = iconImage:Clone()
-iconWithTextImage.Parent = iconFrame
 
 --CREATE DROPDOWN
 local dropdown = Instance.new("Frame")


### PR DESCRIPTION
I can't remember which game I saw something like this in, but I saw this in some game and thought it would be a good idea to add to Topbar+.
Something like this would be nice: https://www.roblox.com/games/5258546945/HD-testing
Right now its another icon template or "type" so if you create an icon with text you cannot make it a "normal" icon without deleting it and creating a new one.

Note: In controller mode, the icon and text offset from the sides is a bit weird at the moment.