### PR TITLE
Farland Command

### DIFF
--- a/src/Commands/Mod/Teleport.lua
+++ b/src/Commands/Mod/Teleport.lua
@@ -3,7 +3,10 @@ local ORDER = 340
 local ROLE = "Ability"
 local modules = script:FindFirstAncestor("HD Admin").Core.MainModule.Value.Modules
 local Task = require(modules.Objects.Task)
+local TeleportAsync = require(modules.PlayerUtil.teleportAsync)
 local getHumanoid = require(modules.PlayerUtil.getHumanoid)
+local getDescription = require(modules.PlayerUtil.getDescription)
+local getHRPPos = require(modules.PlayerUtil.getHRPPos)
 local commands: Task.Commands = {
 
     --------------------
@@ -57,10 +60,9 @@ local commands: Task.Commands = {
 		args = {"Player"},
 		run = function(task, args: {any})
 			local target = args[1]
-			local oldLocation = target.Character.HumanoidRootPart.CFrame
+			local oldLocation = getHRP(target).CFrame
 			task:keep("Indefinitely")
 			task:buff(target,"HumanoidDescription", function(hasEnded, isTop)
-				oldLocation = target.Character.HumanoidRootPart.CFrame
 				local humanoid = getHumanoid(target)
 				local location = if hasEnded then oldLocation else CFrame.new(583648,683648,583648)
 				if humanoid then


### PR DESCRIPTION
A command which teleports you to a point where your Roblox character starts glitching out a bit.
The command in itself repeats upon respawn and can only be stopped via ;unfarland.